### PR TITLE
ocr_it only returns the first box in boxes

### DIFF
--- a/Automatic Number Plate Detection.ipynb
+++ b/Automatic Number Plate Detection.ipynb
@@ -991,9 +991,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def save_results(texts, regions):\n",
+    "def save_results(texts, regions, csv_filename, folder_path):\n",
     "    for idx, region in enumerate(regions):\n",
-    "    save_result(texts[idx], region, 'detection_results.csv', 'Detection_Images')"
+    "    save_result(texts[idx], region, csv_filename, folder_path)"
    ]
   },
   {

--- a/Automatic Number Plate Detection.ipynb
+++ b/Automatic Number Plate Detection.ipynb
@@ -975,7 +975,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def save_results(text, region, csv_filename, folder_path):\n",
+    "def save_result(text, region, csv_filename, folder_path):\n",
     "    img_name = '{}.jpg'.format(uuid.uuid1())\n",
     "    \n",
     "    cv2.imwrite(os.path.join(folder_path, img_name), region)\n",
@@ -991,7 +991,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "regions"
+    "def save_results(texts, regions):\n",
+    "    for idx, region in enumerate(regions):\n",
+    "    save_results(texts[idx], region, 'detection_results.csv', 'Detection_Images')"
    ]
   },
   {
@@ -1000,8 +1002,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for idx, region in enumerate(regions):\n",
-    "    save_results(texts[idx], region, 'detection_results.csv', 'Detection_Images')"
+    "regions"
    ]
   },
   {
@@ -1060,12 +1061,12 @@
     "                category_index,\n",
     "                use_normalized_coordinates=True,\n",
     "                max_boxes_to_draw=5,\n",
-    "                min_score_thresh=.8,\n",
+    "                min_score_thresh=detection_threshold,\n",
     "                agnostic_mode=False)\n",
     "    \n",
     "    try: \n",
-    "        text, region = ocr_it(image_np_with_detections, detections, detection_threshold, region_threshold)\n",
-    "        save_results(text, region, 'realtimeresults.csv', 'Detection_Images')\n",
+    "        texts, regions = ocr_it(image_np_with_detections, detections, detection_threshold, region_threshold)\n",
+    "        save_results(texts, regions, 'realtimeresults.csv', 'Detection_Images')\n",
     "    except:\n",
     "        pass\n",
     "\n",

--- a/Automatic Number Plate Detection.ipynb
+++ b/Automatic Number Plate Detection.ipynb
@@ -903,6 +903,10 @@
    "source": [
     "def ocr_it(image, detections, detection_threshold, region_threshold):\n",
     "    \n",
+    "    # We may have more than one number plate in an image\n",
+    "    texts = []\n",
+    "    regions = []\n",
+    "\n",
     "    # Scores, boxes and classes above threhold\n",
     "    scores = list(filter(lambda x: x> detection_threshold, detections['detection_scores']))\n",
     "    boxes = detections['detection_boxes'][:len(scores)]\n",
@@ -920,11 +924,11 @@
     "        ocr_result = reader.readtext(region)\n",
     "        \n",
     "        text = filter_text(region, ocr_result, region_threshold)\n",
-    "        \n",
-    "        plt.imshow(cv2.cvtColor(region, cv2.COLOR_BGR2RGB))\n",
-    "        plt.show()\n",
-    "        print(text)\n",
-    "        return text, region"
+    "\n",
+    "        texts.append(test)\n",
+    "        regions.append(region)\n",
+    "    \n",
+    "    return texts, regions"
    ]
   },
   {
@@ -935,7 +939,7 @@
    },
    "outputs": [],
    "source": [
-    "text, region = ocr_it(image_np_with_detections, detections, detection_threshold, region_threshold)"
+    "texts, regions = ocr_it(image_np_with_detections, detections, detection_threshold, region_threshold)"
    ]
   },
   {

--- a/Automatic Number Plate Detection.ipynb
+++ b/Automatic Number Plate Detection.ipynb
@@ -925,8 +925,9 @@
     "        \n",
     "        text = filter_text(region, ocr_result, region_threshold)\n",
     "\n",
-    "        texts.append(text[0])\n",
-    "        regions.append(region)\n",
+    "        if(text!=[]):\n",
+    "            texts.append(text[0])\n",
+    "            regions.append(region)\n",
     "    \n",
     "    return texts, regions"
    ]

--- a/Automatic Number Plate Detection.ipynb
+++ b/Automatic Number Plate Detection.ipynb
@@ -993,7 +993,7 @@
    "source": [
     "def save_results(texts, regions):\n",
     "    for idx, region in enumerate(regions):\n",
-    "    save_results(texts[idx], region, 'detection_results.csv', 'Detection_Images')"
+    "    save_result(texts[idx], region, 'detection_results.csv', 'Detection_Images')"
    ]
   },
   {

--- a/Automatic Number Plate Detection.ipynb
+++ b/Automatic Number Plate Detection.ipynb
@@ -925,7 +925,7 @@
     "        \n",
     "        text = filter_text(region, ocr_result, region_threshold)\n",
     "\n",
-    "        texts.append(test)\n",
+    "        texts.append(text)\n",
     "        regions.append(region)\n",
     "    \n",
     "    return texts, regions"

--- a/Automatic Number Plate Detection.ipynb
+++ b/Automatic Number Plate Detection.ipynb
@@ -991,7 +991,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "region"
+    "regions"
    ]
   },
   {
@@ -1000,7 +1000,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "save_results(text, region, 'detection_results.csv', 'Detection_Images')"
+    "for idx, region in enumerate(regions):\n",
+    "    save_results(texts[idx], region, 'detection_results.csv', 'Detection_Images')"
    ]
   },
   {

--- a/Automatic Number Plate Detection.ipynb
+++ b/Automatic Number Plate Detection.ipynb
@@ -993,7 +993,7 @@
    "source": [
     "def save_results(texts, regions, csv_filename, folder_path):\n",
     "    for idx, region in enumerate(regions):\n",
-    "    save_result(texts[idx], region, csv_filename, folder_path)"
+    "        save_result(texts[idx], region, csv_filename, folder_path)"
    ]
   },
   {

--- a/Automatic Number Plate Detection.ipynb
+++ b/Automatic Number Plate Detection.ipynb
@@ -925,7 +925,7 @@
     "        \n",
     "        text = filter_text(region, ocr_result, region_threshold)\n",
     "\n",
-    "        texts.append(text)\n",
+    "        texts.append(text[0])\n",
     "        regions.append(region)\n",
     "    \n",
     "    return texts, regions"


### PR DESCRIPTION
If an image has more than one number plate then ocr_it will only return one of them...

```Python
def ocr_it(image, detections, detection_threshold, region_threshold):
    
    # Scores, boxes and classes above threhold
    scores = list(filter(lambda x: x> detection_threshold, detections['detection_scores']))
    boxes = detections['detection_boxes'][:len(scores)]
    classes = detections['detection_classes'][:len(scores)]
    
    # Full image dimensions
    width = image.shape[1]
    height = image.shape[0]
    
    # Apply ROI filtering and OCR
    for idx, box in enumerate(boxes):
        roi = box*[height, width, height, width]
        region = image[int(roi[0]):int(roi[2]),int(roi[1]):int(roi[3])]
        reader = easyocr.Reader(['en'])
        ocr_result = reader.readtext(region)
        
        text = filter_text(region, ocr_result, region_threshold)
        
        plt.imshow(cv2.cvtColor(region, cv2.COLOR_BGR2RGB))
        plt.show()
        print(text)
        return text, region
```

The return shouldn't be there. It should be more like...

```Python
def ocr_it(image, detections, detection_threshold, region_threshold):
    
    # We may have more than one number plate in an image
    texts = []
    regions = []

    # Scores, boxes and classes above threhold
    scores = list(filter(lambda x: x> detection_threshold, detections['detection_scores']))
    boxes = detections['detection_boxes'][:len(scores)]
    classes = detections['detection_classes'][:len(scores)]
    
    # Full image dimensions
    width = image.shape[1]
    height = image.shape[0]
    
    # Apply ROI filtering and OCR
    for idx, box in enumerate(boxes):
        roi = box*[height, width, height, width]
        region = image[int(roi[0]):int(roi[2]),int(roi[1]):int(roi[3])]
        reader = easyocr.Reader(['en'])
        ocr_result = reader.readtext(region)
        
        text = filter_text(region, ocr_result, region_threshold)

        if(text!=[]):
            texts.append(text[0])
            regions.append(region)
    
    return texts, regions
```

That means the function save_results won't work and also needs to be change to something like...

```Python
def save_result(text, region, csv_filename, folder_path):
    img_name = '{}.jpg'.format(uuid.uuid1())
    
    cv2.imwrite(os.path.join(folder_path, img_name), region)
    
    with open(csv_filename, mode='a', newline='') as f:
        csv_writer = csv.writer(f, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
        csv_writer.writerow([img_name, text])

def save_results(texts, regions, csv_filename, folder_path):
    for idx, region in enumerate(regions):
        save_result(texts[idx], region, csv_filename, folder_path)
```

There is also a hard coded detection threshold in the live detection that I changed to the variable `detection_threshold`

I realize if you do a merge then your video will be out of step with the code but I thought that I would send you one anyway.

Cheers,
Jonti 